### PR TITLE
fix: add function to calculate video duration using ffmpeg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "fluent-ffmpeg": "^2.1.3",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.9.1",
         "mongoose-aggregate-paginate-v2": "^1.1.2",
@@ -107,6 +108,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -596,6 +602,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -890,6 +909,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -2063,6 +2088,18 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "fluent-ffmpeg": "^2.1.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.9.1",
     "mongoose-aggregate-paginate-v2": "^1.1.2",

--- a/src/models/video.model.js
+++ b/src/models/video.model.js
@@ -28,10 +28,10 @@ const videoSchema = new Schema(
             type: Number,
             default: 0
         },
-        likes: {
-            type: Schema.Types.ObjectId, //added by me
-            default: "Like"
-        },
+        //likes: {
+        //    type: Schema.Types.ObjectId, //added by me
+        //    default: "Like"
+        //},
         isPublished: {
             type: Boolean,
             default: true


### PR DESCRIPTION
I have implemented a method that uses the `ffmpeg` library to calculate the duration of the uploaded video in read time. Previously, it was not working because we were trying to calculate the duration of the video after it was already uploaded on cloudinary platform.
`const thumbnail = await uploadOnCloudinary(thumbnailPath)`
We were trying to calculate the duration of the video after the execution of the above method.
Now, there is a major problem with this approach. Primarily, if we see the execution of the `uploadOnCloudinary` method,
```
try {
        if (!localFilePath) return null
        //upload the file on cloudinary
        const response = await cloudinary.uploader.upload(localFilePath, {
            resource_type: "auto"
        })
        // file has been uploaded successfull
        //console.log("file is uploaded on cloudinary ", response.url);
        fs.unlinkSync(localFilePath)
        return response;

    } catch (error) {
        console.log(error)
        fs.unlinkSync(localFilePath) // remove the locally saved temporary file as the upload operation got failed
        return null;
    }
```
It uploads the video and then unlinks it using the fs package, which basically deletes the video from our folder location after it has been successfully uploaded.
So ideally, we should calculate the duration of the video before it has been uploaded and deleted from our folder location.